### PR TITLE
fix mismatch from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ const openai = new OpenAI(OPEN_AI_API_KEY);
     maxTokens: 5,
     temperature: 0.9,
     topP: 1,
-    presence_penalty: 0,
-    frequency_penalty: 0,
-    best_of: 1,
+    presencePenalty: 0,
+    frequencyPenalty: 0,
+    bestOf: 1,
     n: 1,
     stream: false,
     stop: ['\n', "testing"]


### PR DESCRIPTION
fix mismatch from README and request objects - solution was to change README documentation to use javascript casing standards.

closes #10 