### PR TITLE
feat: allow the specification of a model for fine tuned completion

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,6 +7,9 @@ module.exports = {
   completionURL(engine) {
     return `${OPEN_AI_URL}/engines/${engine}/completions`;
   },
+  fineTunedCompletionURL() {
+    return `${OPEN_AI_URL}/completions`;
+  },
   searchURL(engine) {
     return `${OPEN_AI_URL}/engines/${engine}/search`;
   },

--- a/index.js
+++ b/index.js
@@ -33,7 +33,9 @@ class OpenAI {
   }
 
   complete(opts) {
-    const url = config.completionURL(opts.engine || DEFAULT_ENGINE);
+    const url = opts.model
+      ? config.fineTunedCompletionURL()
+      : config.completionURL(opts.engine || DEFAULT_ENGINE);
     delete opts.engine;
 
     return this._send_request(url, 'post', opts);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "openai-api",
-  "version": "1.1.2",
+  "version": "1.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "openai-api",
-      "version": "1.1.2",
+      "version": "1.2.6",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.1",


### PR DESCRIPTION
When using a fine-tuned model, you specify a model rather than an engine - see:

https://beta.openai.com/docs/guides/fine-tuning/use-a-fine-tuned-model

This adds support for a model parameter, e.g.

~~~
  const gptResponse = await openai.complete({
    model: "curie:MODEL-ID",
    prompt
  });
~~~