### PR TITLE
Update typings to latest version and add missing function calls to OpenAI class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,30 +1,30 @@
+import { ClassificationOpts } from './index.d';
 declare module 'openai-api' {
     export interface CompletionOpts {
-        engine: string;
+        model: string;
         prompt?: string;
-        maxTokens?: number;
+        suffix?: string;
+        max_tokens?: number;
         temperature?: number;
-        topP?: number;
+        top_p?: number;
         n?: number;
         stream?: boolean;
         logprobs?: number;
         echo?: boolean;
         stop?: string | string[];
-        presencePenalty?: number;
-        frequencyPenalty?: number;
-        bestOf?: number;
+        presence_penalty?: number;
+        frequency_penalty?: number;
+        best_of?: number;
         user?: string;
-        logitBias?: { [token: string]: number; };
+        logit_bias?: { [token: string]: number; };
     }
 
     export interface Completion {
-        data: {
-            id: string;
-            object: string;
-            created: number;
-            model: string;
-            choices: Choice[];
-        };
+        id: string;
+        object: string;
+        created: number;
+        model: string;
+        choices: Choice[];
     }
 
     export interface Choice {
@@ -35,12 +35,13 @@ declare module 'openai-api' {
     }
 
     export interface SearchOpts {
-        engine: string;
+        engine_id: string;
+        query: string;
         documents?: string[];
         file?: string;
-        query: string;
-        maxRerank?: number;
-        returnMetadata?: boolean;
+        max_rerank?: number;
+        return_metadata?: boolean;
+        user?: string;
     }
 
     export interface Search {
@@ -55,10 +56,98 @@ declare module 'openai-api' {
         metadata?: any;
     }
 
+    export interface AnswerOpts {
+        model: string;
+        question: string;
+        examples: string[][];
+        examples_context: string;
+        documents?: string[];
+        file?: string;
+        search_model?: string;
+        max_rerank?: number;
+        temperature?: number;
+        logprobs?: number;
+        max_tokens?: number;
+        stop?: string | string[];
+        n?: number;
+        logit_bias?: LogitBias;
+        return_metadata?: boolean;
+        return_prompt?: boolean;
+        expand?: string[];
+        user?: string;
+    }
+
+    export interface LogitBias {
+        [key: string]: number;
+    }
+
+    export interface Answer {
+        answers: string[],
+        completion: string;
+        modeL: string;
+        object: string;
+        search_model: string;
+        selected_documents:  AnswerDocument[];
+    }
+
+    export interface AnswerDocument {
+        document: number;
+        text: string;
+    }
+
+    export interface ClassificationOpts {
+        model: string;
+        query: string;
+        examples?: string[][];
+        file?: string;
+        labels?: string[];
+        search_model?: string;
+        temperature?: string;
+        logprobs?: number;
+        max_examples?: number;
+        logit_bias?: LogitBias;
+        return_prompt?: boolean;
+        return_metadata?: boolean;
+        expand?: string[];
+        user?: string;
+    }
+
+    export interface Classification {
+        completion: string;
+        label: string;
+        model: string;
+        object: string;
+        search_model: string;
+        selected_examples: ClassificationDocument;
+    }
+
+    export interface ClassificationDocument {
+        document: number;
+        label: string;
+        text: string;
+    }
+
+    export interface EngineData {
+        data: Engine[];
+        object: string;
+    }
+
+    export interface EmbeddingOpts {
+        model: string;
+        input: string;
+        user?: string;
+    }
+
+    export interface Engine {
+        id: string;
+        object: string;
+        owner: string;
+        ready: boolean;
+    }
+
     export interface Embedding {
         object: string;
         data: EmbeddingData[];
-        model: string;
     }
 
     export interface EmbeddingData {
@@ -69,9 +158,22 @@ declare module 'openai-api' {
 
     class OpenAI {
         constructor(api: string);
-        complete(opts: CompletionOpts): Promise<Completion>;
+        
+        async complete(opts: CompletionOpts): Promise<Completion>;
+        
         encode(str: string): number[];
-        search(opts: SearchOpts): Promise<Search>;
+        
+        async search(opts: SearchOpts): Promise<Search>;
+        
+        async answers(opts: AnswerOpts): Promise<Answer>;
+        
+        async classification(opts: ClassificationOpts): Promise<Classification>;
+
+        async engines(): Promise<EngineData>;
+
+        async engine(): Promise<Engine>;
+
+        async embeddings(): Promise<Embedding>;
     }
 
     export default OpenAI;

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ class OpenAI {
     });
   }
 
-  _check_embeddings_engine_name(engine) {
+  _check_embeddings_engine_name(model) {
     const availableEngineNames = [
       'text-similarity-ada-001',
       'text-similarity-babbage-001',
@@ -52,7 +52,7 @@ class OpenAI {
       'code-search-babbage-text-001',
     ];
 
-    if (!availableEngineNames.includes(engine)) {
+    if (!availableEngineNames.includes(model)) {
       throw new Error(`Unknown engine name for embeddings. Available engine names are ${availableEngineNames}`);
     }
   }
@@ -96,9 +96,9 @@ class OpenAI {
   }
 
   embeddings(opts) {
-    this._check_embeddings_engine_name(opts.engine);
+    this._check_embeddings_engine_name(opts.model);
 
-    const url = config.embeddingsUrl(opts.engine);
+    const url = config.embeddingsUrl(opts.model);
     return this._send_request(url, 'post', opts);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-api",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "description": "A tiny client module for the openAI API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I just found that OpenAI class in `index.d.ts` lacks function calls that are defined in OpenAI class in `index.js`. Therefore I am not able to call these functions within a Typescript project. I added them so that I can properly call them. Also I found out that Typings are not up to date with the current API (for example `engine` was renamed to `model`). I fixed those too. Can you check this and then push the latest changes to npm. Thank you. If something is missing let me know :) Thanks for your time!

OpenAI API is defined here https://beta.openai.com/docs/api-reference